### PR TITLE
Support chain_id=None for backward compatibility (prevent EIP-155 additions).

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pip install blocksec2go-ethereum
 
 After creating an instance of `Blocksec2Go` you can use it to generate signatures for transaction dicts. When passed raw tx, `sign_transaction()` will return a hex string of RLP-encoded signed transaction that can be directly consumed by `web3.eth.sendRawTransaction()`.
 
+The replay attack protection introduced with [EIP-155](https://eips.ethereum.org/EIPS/eip-155) is used by default. Set `chain_id=None` to force the legacy behaviour for backward compatibility.
 ### Transfer Ether
 
 Below you will find an example of signing a simple Ether transfer:

--- a/blocksec2go_ethereum/_signer.py
+++ b/blocksec2go_ethereum/_signer.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Tuple
+from typing import Tuple, Optional
 
 import blocksec2go
 from blocksec2go.comm.pyscard import open_pyscard
@@ -18,7 +18,7 @@ Signature = Tuple[int, int, int]
 
 
 class Blocksec2GoSigner:
-    def __init__(self, key_id: int = 1, chain_id: int = 1, connect_retry_count: int = 5):
+    def __init__(self, key_id: int = 1, chain_id: Optional[int] = 1, connect_retry_count: int = 5):
         self._key_id = key_id
         self._chain_id = chain_id
         self._connect_retry_count = connect_retry_count

--- a/blocksec2go_ethereum/_utils.py
+++ b/blocksec2go_ethereum/_utils.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Optional
 
 import ecdsa
 from eth_typing import ChecksumAddress
@@ -34,6 +34,9 @@ def address_from_public_key(public_key: bytes) -> ChecksumAddress:
     return Web3.toChecksumAddress(address)
 
 
-def get_v(sig: UnrecoverableSignature, tx_hash: bytes, pub_key: bytes, chain_id: int) -> int:
+def get_v(sig: UnrecoverableSignature, tx_hash: bytes, pub_key: bytes, chain_id: Optional[int]) -> int:
     recovery_id = find_recovery_id(sig, tx_hash, pub_key)
+
+    if not chain_id:
+        return 27 + recovery_id
     return 35 + recovery_id + (chain_id * 2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,3 +28,9 @@ def test_address_from_public_key():
 def test_get_v():
     returned_v = get_v(test_unrecoverable_signature, test_tx_hash, test_pub_key, test_chain_id)
     assert test_signature[0] == returned_v
+
+
+def test_get_v_legacy():
+    returned_v = get_v(test_unrecoverable_signature, test_tx_hash, test_pub_key, None)
+    legacy_v = test_signature[0] - (2 * test_chain_id) - 35 + 27
+    assert legacy_v == returned_v


### PR DESCRIPTION
Hello,

the internally used package 'eth_account' supports the legacy format (pre EIP-155) to create the transaction object and return the transaction hash to be signed with the blocksec card. This old format is still used by forked chains mainly in private networks.

However, blocksec2go-ethereum fails when recovering the V-value:

>  return 35 + recovery_id + (chain_id * 2)
>   E       TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
>    ..\blocksec2go_ethereum\_utils.py:39: TypeError

Please consider my changes, it would allow me to interface a private legacy-chain for a test application.

Thanks,
Alex